### PR TITLE
Fix compile error u_int32_t

### DIFF
--- a/components/mi/mi.cpp
+++ b/components/mi/mi.cpp
@@ -407,7 +407,7 @@ namespace esphome {
       
        while (millis() - lastRequestTime > repeatTimer && bulbCompactIds.Count() > 0) {
 
-        u_int32_t bulbCompactId = bulbCompactIds.First();
+        uint32_t bulbCompactId = bulbCompactIds.First();
         bulbCompactIds.RemoveFirst();
         Request request = requests.First();
         requests.RemoveFirst();


### PR DESCRIPTION
Fix typo in type specification causing compile error. 

`u_int32_t` should be `uint32_t` I believe.