### PR TITLE
Support for setting color temperature range

### DIFF
--- a/components/mi/light/__init__.py
+++ b/components/mi/light/__init__.py
@@ -44,8 +44,8 @@ CONFIG_SCHEMA = cv.All(
                 CONF_DEFAULT_TRANSITION_LENGTH, default="200ms"
             ): cv.positive_time_period_milliseconds,
 
-            cv.Optional(CONF_COLD_WHITE_COLOR_TEMPERATURE, default=153): cv.color_temperature,
-            cv.Optional(CONF_WARM_WHITE_COLOR_TEMPERATURE, default=370): cv.color_temperature,
+            cv.Optional(CONF_COLD_WHITE_COLOR_TEMPERATURE, default="153 mireds"): cv.color_temperature,
+            cv.Optional(CONF_WARM_WHITE_COLOR_TEMPERATURE, default="370 mireds"): cv.color_temperature,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     light.validate_color_temperature_channels,

--- a/components/mi/light/__init__.py
+++ b/components/mi/light/__init__.py
@@ -61,4 +61,7 @@ async def to_code(config):
     cg.add(var.set_mi_parent(paren))
     
     cg.add(var.set_bulb_id(config[CONF_DEVICEID], config[CONF_GROUPID], config[CONF_REMOTETYPE]))
+
+    cg.add(var.set_cold_white_temperature(config[CONF_COLD_WHITE_COLOR_TEMPERATURE]))
+    cg.add(var.set_warm_white_temperature(config[CONF_WARM_WHITE_COLOR_TEMPERATURE]))
    

--- a/components/mi/light/__init__.py
+++ b/components/mi/light/__init__.py
@@ -5,6 +5,8 @@ from esphome.const import (
     CONF_OUTPUT_ID,
     CONF_DEFAULT_TRANSITION_LENGTH,
     CONF_GAMMA_CORRECT,
+    CONF_COLD_WHITE_COLOR_TEMPERATURE,
+    CONF_WARM_WHITE_COLOR_TEMPERATURE,
 )
 from .. import mi_ns, CONF_MI_ID, Mi
 
@@ -41,6 +43,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_DEFAULT_TRANSITION_LENGTH, default="200ms"
             ): cv.positive_time_period_milliseconds,
+
+            cv.Optional(CONF_COLD_WHITE_COLOR_TEMPERATURE, default=153): cv.color_temperature,
+            cv.Optional(CONF_WARM_WHITE_COLOR_TEMPERATURE, default=370): cv.color_temperature,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     light.validate_color_temperature_channels,

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -100,7 +100,19 @@ namespace esphome {
       }
     }
 
+    float mi_color_temperature(float real_color_temperature) {
+      const auto MI_MIN = 153;
+      const auto MI_MAX = 370;
+      const auto MI_RANGE = MI_MAX - MI_MIN;
+      float range = warm_white_temperature_ - cold_white_temperature_;
+      float pct = (real_color_temperature - cold_white_temperature_) / range;
+      return pct * MI_RANGE + MI_MIN;
+    }
+
     void MiLight::write_state(light::LightState *state) {
+      state->current_values.set_color_temperature(
+        mi_color_temperature(state->current_values.get_color_temperature())
+      );
       parent_->write_state(bulbId, state);
     }
   }  // namespace mi

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -100,15 +100,6 @@ namespace esphome {
       }
     }
 
-    float MiLight::mi_color_temperature(float real_color_temperature) {
-      const auto MI_MIN = 153;
-      const auto MI_MAX = 370;
-      const auto MI_RANGE = MI_MAX - MI_MIN;
-      float range = warm_white_temperature_ - cold_white_temperature_;
-      float pct = (real_color_temperature - cold_white_temperature_) / range;
-      return pct * MI_RANGE + MI_MIN;
-    }
-
     void MiLight::write_state(light::LightState *state) {
       state->current_values.set_color_temperature(
         mi_color_temperature(state->current_values.get_color_temperature())

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -36,8 +36,8 @@ namespace esphome {
       switch (MiLight::bulbId.deviceType) {
         case REMOTE_TYPE_RGB_CCT:
           traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE});
-          traits.set_max_mireds(370);
-          traits.set_min_mireds(153);
+          traits.set_max_mireds(warm_white_temperature_);
+          traits.set_min_mireds(cold_white_temperature_);
           break;
         case REMOTE_TYPE_RGB:
           traits.set_supported_color_modes({light::ColorMode::RGB});
@@ -47,18 +47,18 @@ namespace esphome {
           break;
         case REMOTE_TYPE_CCT:
           traits.set_supported_color_modes({light::ColorMode::COLOR_TEMPERATURE});
-          traits.set_max_mireds(370);
-          traits.set_min_mireds(153);
+          traits.set_max_mireds(warm_white_temperature_);
+          traits.set_min_mireds(cold_white_temperature_);
           break;
         case REMOTE_TYPE_FUT089:
           traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE});
-          traits.set_max_mireds(370);
-          traits.set_min_mireds(153);
+          traits.set_max_mireds(warm_white_temperature_);
+          traits.set_min_mireds(cold_white_temperature_);
           break;
         case REMOTE_TYPE_FUT091:
           traits.set_supported_color_modes({light::ColorMode::COLOR_TEMPERATURE});
-          traits.set_max_mireds(370);
-          traits.set_min_mireds(153);
+          traits.set_max_mireds(warm_white_temperature_);
+          traits.set_min_mireds(cold_white_temperature_);
           break;
         case REMOTE_TYPE_FUT020:
           traits.set_supported_color_modes({light::ColorMode::RGB});

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -100,7 +100,7 @@ namespace esphome {
       }
     }
 
-    float mi_color_temperature(float real_color_temperature) {
+    float MiLight::mi_color_temperature(float real_color_temperature) {
       const auto MI_MIN = 153;
       const auto MI_MAX = 370;
       const auto MI_RANGE = MI_MAX - MI_MIN;

--- a/components/mi/light/mi_light.h
+++ b/components/mi/light/mi_light.h
@@ -27,7 +27,6 @@ namespace esphome {
     void set_cold_white_temperature(float cold_white_temperature) { cold_white_temperature_ = cold_white_temperature; }
     void set_warm_white_temperature(float warm_white_temperature) { warm_white_temperature_ = warm_white_temperature; }
 
-   protected:
     float mi_color_temperature(float real_color_temperature) {
       float pct = (real_color_temperature - cold_white_temperature_) / color_temperature_range();
       return pct * MI_MIREDS_RANGE + MI_MIREDS_MIN;

--- a/components/mi/light/mi_light.h
+++ b/components/mi/light/mi_light.h
@@ -26,15 +26,28 @@ namespace esphome {
 
     void set_cold_white_temperature(float cold_white_temperature) { cold_white_temperature_ = cold_white_temperature; }
     void set_warm_white_temperature(float warm_white_temperature) { warm_white_temperature_ = warm_white_temperature; }
-    float mi_color_temperature(float real_color_temperature);
+
+   protected:
+    float mi_color_temperature(float real_color_temperature) {
+      float pct = (real_color_temperature - cold_white_temperature_) / color_temperature_range();
+      return pct * MI_MIREDS_RANGE + MI_MIREDS_MIN;
+    }
+    float real_color_temperature(float mi_color_temperature) {
+      float pct = (mi_color_temperature - MI_MIREDS_MIN) / MI_MIREDS_RANGE;
+      return pct * color_temperature_range() + cold_white_temperature_;
+    }
 
    private:
+    const float MI_MIREDS_MIN = 153;
+    const float MI_MIREDS_MAX = 370;
+    const float MI_MIREDS_RANGE = MI_MIREDS_MAX - MI_MIREDS_MIN;
+    float cold_white_temperature_;
+    float warm_white_temperature_;
+    float color_temperature_range() { return warm_white_temperature_ - cold_white_temperature_; }
+
     BulbId bulbId = {0, 0, REMOTE_TYPE_RGB_CCT};
     Mi *parent_;
     light::LightState *state_{nullptr};
-
-    float cold_white_temperature_;
-    float warm_white_temperature_;
   };
 
   }  // namespace mi

--- a/components/mi/light/mi_light.h
+++ b/components/mi/light/mi_light.h
@@ -24,11 +24,16 @@ namespace esphome {
     void setup_state(light::LightState *state) override;
     void write_state(light::LightState *state) override;
 
-   private:
+    void set_cold_white_temperature(float cold_white_temperature) { cold_white_temperature_ = cold_white_temperature; }
+    void set_warm_white_temperature(float warm_white_temperature) { warm_white_temperature_ = warm_white_temperature; }
 
+   private:
     BulbId bulbId = {0, 0, REMOTE_TYPE_RGB_CCT};
     Mi *parent_;
     light::LightState *state_{nullptr};
+
+    float cold_white_temperature_;
+    float warm_white_temperature_;
   };
 
   }  // namespace mi

--- a/components/mi/light/mi_light.h
+++ b/components/mi/light/mi_light.h
@@ -26,6 +26,7 @@ namespace esphome {
 
     void set_cold_white_temperature(float cold_white_temperature) { cold_white_temperature_ = cold_white_temperature; }
     void set_warm_white_temperature(float warm_white_temperature) { warm_white_temperature_ = warm_white_temperature; }
+    float mi_color_temperature(float real_color_temperature);
 
    private:
     BulbId bulbId = {0, 0, REMOTE_TYPE_RGB_CCT};

--- a/components/mi/mi.cpp
+++ b/components/mi/mi.cpp
@@ -159,10 +159,12 @@ namespace esphome {
         state->remote_values.set_state(result["state"] == "ON");
       }
       if (result.containsKey("color_temp")) {
+        MiLight* output = (MiLight*)(state->get_output());
+        float color_temp = output->real_color_temperature((float)result["color_temp"]);
         state->current_values.set_color_mode(light::ColorMode::COLOR_TEMPERATURE);
-        state->current_values.set_color_temperature((float)result["color_temp"]);
+        state->current_values.set_color_temperature(color_temp);
         state->remote_values.set_color_mode(light::ColorMode::COLOR_TEMPERATURE);
-        state->remote_values.set_color_temperature((float)result["color_temp"]);
+        state->remote_values.set_color_temperature(color_temp);
       }
       if (result.containsKey("brightness")) {
         state->current_values.set_brightness((float)result["brightness"]/255.00);

--- a/components/mi/mi.cpp
+++ b/components/mi/mi.cpp
@@ -153,13 +153,13 @@ namespace esphome {
     }
 
     void Mi::updateOutput(light::LightState *state, JsonObject result) {
-      
+
+      MiLight* output = (MiLight*)(state->get_output());
       if (result.containsKey("state")) {
         state->current_values.set_state(result["state"] == "ON");
         state->remote_values.set_state(result["state"] == "ON");
       }
       if (result.containsKey("color_temp")) {
-        MiLight* output = (MiLight*)(state->get_output());
         float color_temp = output->real_color_temperature((float)result["color_temp"]);
         state->current_values.set_color_mode(light::ColorMode::COLOR_TEMPERATURE);
         state->current_values.set_color_temperature(color_temp);
@@ -205,7 +205,7 @@ namespace esphome {
         colorMode = false;
       }     
       state->publish_state();
-      state->get_output()->update_state(state);
+      output->update_state(state);
     }
 
     void Mi::handleCommand(BulbId bulbId, String command) {

--- a/example_milight.yaml
+++ b/example_milight.yaml
@@ -73,6 +73,10 @@ light:
     group_id: 1 #required, 1-4 or 1-8, depending on remote type
     remote_type: rgb_cct #required, possible values: rgb_cct, rgb, cct, rgbw, fut089, fut091, fut020
     default_transition_length: 0s #optional, but 0s gives a better behaviour instead the default 200ms
+  # Set these to calibrate the color temperature of your light, measured with an external color temp. sensor or app
+  # optional, [153, 370] mireds is the range miboxer uses internally ([6535, 2702] K)
+    #cold_white_color_temperature: 6500 K
+    #warm_white_color_temperature: 2700 K
 # optional variables: all variables of ESPHome base light component
 
 binary_sensor:


### PR DESCRIPTION
**Problem**: the color temperature in HA is not correct. _MiLight LED strip controllers can be paired with arbitrary LED strips, but theoretically the MiLight bulbs should should have the same color temp range, which could be hard-coded based on the model, so the user would just have to specify their bulb model. This is not supported in this pull request though_

**Solution**: add `cold_white_color_temperature` and `warm_white_color_temperature` yaml options. 

Originally simply based on the `color_temperature` component, but I noticed this also changed the reachable color temp range in HA. So I assumed that the hard-coded [153, 370] mireds range is the internal range used by MiBoxer (please correct me if wrong here). I added a mapping between the user-defined range and the [153, 370] range, which seems to work now.

_PS. I don't have a very accuracy way of measuring the color temperature, but I just got an app from Play Store (`Color Temperature Meter`), which seems to give reasonable readings with my phone (camera AWB can completely break this) when looking at diffuse light on white paper (only the measured light turned on, no bright spots on the paper). I think the values may be dependent on the environment (color of your light fixture, walls, etc.), but I got these ranges for my two bulbs (which didn't match with the stock values):_
* FUT105: [3250 K, 6250 K]
* FUT102: [3700 K, 6400 K]
