### PR TITLE
S2 support

### DIFF
--- a/components/mi/MiLightRemoteConfig.cpp
+++ b/components/mi/MiLightRemoteConfig.cpp
@@ -11,7 +11,8 @@ const MiLightRemoteConfig* MiLightRemoteConfig::ALL_REMOTES[] = {
   &FUT098Config, // rgb
   &FUT089Config, // 8-group rgb+cct (b8, fut089)
   &FUT091Config,
-  &FUT020Config
+  &FUT020Config,
+  &S2Config
 };
 
 const size_t MiLightRemoteConfig::NUM_REMOTES = size(ALL_REMOTES);
@@ -105,4 +106,12 @@ const MiLightRemoteConfig FUT020Config(
   REMOTE_TYPE_FUT020,
   "fut020",
   0
+);
+
+const MiLightRemoteConfig S2Config( //rgb+cct
+  new S2PacketFormatter(),
+  MiLightRadioConfig::ALL_CONFIGS[2],
+  REMOTE_TYPE_S2,
+  "s2",
+  4
 );

--- a/components/mi/MiLightRemoteConfig.h
+++ b/components/mi/MiLightRemoteConfig.h
@@ -8,6 +8,7 @@
 #include "FUT089PacketFormatter.h"
 #include "FUT091PacketFormatter.h"
 #include "FUT020PacketFormatter.h"
+#include "S2PacketFormatter.h"
 #include "PacketFormatter.h"
 
 #ifndef _MILIGHT_REMOTE_CONFIG_H
@@ -49,5 +50,6 @@ extern const MiLightRemoteConfig FUT089Config; //rgb+cct B8 / FUT089
 extern const MiLightRemoteConfig FUT098Config; //rgb
 extern const MiLightRemoteConfig FUT091Config; //v2 cct
 extern const MiLightRemoteConfig FUT020Config;
+extern const MiLightRemoteConfig S2Config;
 
 #endif

--- a/components/mi/MiLightRemoteType.cpp
+++ b/components/mi/MiLightRemoteType.cpp
@@ -8,6 +8,7 @@ static const char* REMOTE_NAME_FUT089  = "fut089";
 static const char* REMOTE_NAME_RGB     = "rgb";
 static const char* REMOTE_NAME_FUT091  = "fut091";
 static const char* REMOTE_NAME_FUT020  = "fut020";
+static const char* REMOTE_NAME_S2      = "s2";
 
 const MiLightRemoteType MiLightRemoteTypeHelpers::remoteTypeFromString(const String& type) {
   if (type.equalsIgnoreCase(REMOTE_NAME_RGBW) || type.equalsIgnoreCase("fut096")) {
@@ -38,6 +39,10 @@ const MiLightRemoteType MiLightRemoteTypeHelpers::remoteTypeFromString(const Str
     return REMOTE_TYPE_FUT020;
   }
 
+  if (type.equalsIgnoreCase(REMOTE_NAME_S2)) {
+    return REMOTE_TYPE_S2;
+  }
+
   Serial.print(F("remoteTypeFromString: ERROR - tried to fetch remote config for type: "));
   Serial.println(type);
 
@@ -60,6 +65,8 @@ const String MiLightRemoteTypeHelpers::remoteTypeToString(const MiLightRemoteTyp
       return REMOTE_NAME_FUT091;
     case REMOTE_TYPE_FUT020:
       return REMOTE_NAME_FUT020;
+    case REMOTE_TYPE_S2:
+      return REMOTE_NAME_S2;
     default:
       Serial.print(F("remoteTypeToString: ERROR - tried to fetch remote config name for unknown type: "));
       Serial.println(type);
@@ -73,6 +80,7 @@ const bool MiLightRemoteTypeHelpers::supportsRgb(const MiLightRemoteType type) {
     case REMOTE_TYPE_RGB:
     case REMOTE_TYPE_RGB_CCT:
     case REMOTE_TYPE_RGBW:
+    case REMOTE_TYPE_S2:
       return true;
     default:
       return false;
@@ -85,6 +93,7 @@ const bool MiLightRemoteTypeHelpers::supportsColorTemp(const MiLightRemoteType t
     case REMOTE_TYPE_FUT089:
     case REMOTE_TYPE_FUT091:
     case REMOTE_TYPE_RGB_CCT:
+    case REMOTE_TYPE_S2:
       return true;
     default:
       return false;

--- a/components/mi/MiLightRemoteType.h
+++ b/components/mi/MiLightRemoteType.h
@@ -10,7 +10,8 @@ enum MiLightRemoteType {
   REMOTE_TYPE_RGB     = 3,
   REMOTE_TYPE_FUT089  = 4,
   REMOTE_TYPE_FUT091  = 5,
-  REMOTE_TYPE_FUT020  = 6
+  REMOTE_TYPE_FUT020  = 6,
+  REMOTE_TYPE_S2      = 7,
 };
 
 class MiLightRemoteTypeHelpers {

--- a/components/mi/S2PacketFormatter.cpp
+++ b/components/mi/S2PacketFormatter.cpp
@@ -125,7 +125,7 @@ BulbId S2PacketFormatter::parsePacket(const uint8_t *packet, JsonObject result) 
     result[GroupStateFieldNames::HUE] = hue;
   } else if (command == S2_KELVIN) {
     uint8_t temperature = arg;
-    result[GroupStateFieldNames::COLOR_TEMP] = Units::whiteValToMireds(temperature, 100);
+    result[GroupStateFieldNames::KELVIN] = Units::whiteValToMireds(temperature, 100);
   } else if (command == S2_BRIGHTNESS) {
     result[GroupStateFieldNames::BRIGHTNESS] = Units::rescale<uint8_t, uint8_t>(arg, 255, 100);
   } else if (command == S2_SATURATION) {

--- a/components/mi/S2PacketFormatter.cpp
+++ b/components/mi/S2PacketFormatter.cpp
@@ -1,0 +1,141 @@
+#include "S2PacketFormatter.h"
+#include "V2RFEncoding.h"
+#include "Units.h"
+#include "MiLightCommands.h"
+
+void S2PacketFormatter::updateMode(uint8_t mode) {
+  lastMode = mode;
+  command(S2_MODE, mode);
+}
+
+void S2PacketFormatter::nextMode() {
+  updateMode((lastMode+1)%S2_NUM_MODES);
+}
+
+void S2PacketFormatter::previousMode() {
+  updateMode((lastMode-1)%S2_NUM_MODES);
+}
+
+void S2PacketFormatter::updateBrightness(uint8_t brightness) {
+  command(S2_BRIGHTNESS, brightness);
+}
+
+// change the hue (which may also change to color mode).
+void S2PacketFormatter::updateHue(uint16_t value) {
+  uint8_t remapped = Units::rescale(value, 255, 360);
+  updateColorRaw(remapped);
+}
+
+void S2PacketFormatter::updateColorRaw(uint8_t value) {
+  command(S2_COLOR, S2_COLOR_OFFSET + value);
+}
+
+void S2PacketFormatter::updateTemperature(uint8_t value) {
+  // when updating temperature, the bulb switches to white.  If we are not already
+  // in white mode, that makes changing temperature annoying because the current hue/mode
+  // is lost.  So lookup our current bulb mode, and if needed, reset the hue/mode after
+  // changing the temperature
+  const GroupState* ourState = this->stateStore->get(this->deviceId, this->groupId, REMOTE_TYPE_S2);
+
+  // now make the temperature change
+  command(S2_KELVIN, value);
+
+  // and return to our original mode
+  if (ourState != NULL) {
+    BulbMode originalBulbMode = ourState->getBulbMode();
+
+    if ((settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_WHITE)) {
+      switchMode(*ourState, originalBulbMode);
+    }
+  }
+}
+
+// update saturation.  This only works when in Color mode, so if not in color we switch to color,
+// make the change, and switch back again.
+void S2PacketFormatter::updateSaturation(uint8_t value) {
+   // look up our current mode
+  const GroupState* ourState = this->stateStore->get(this->deviceId, this->groupId, REMOTE_TYPE_S2);
+  BulbMode originalBulbMode = BulbMode::BULB_MODE_WHITE;
+
+  if (ourState != NULL) {
+    originalBulbMode = ourState->getBulbMode();
+
+    // are we already in white?  If not, change to white
+    if ((settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_COLOR)) {
+      updateHue(ourState->getHue());
+    }
+  }
+
+  // now make the saturation change
+  command(S2_SATURATION, value);
+
+  if (ourState != NULL) {
+    if ((settings->enableAutomaticModeSwitching) && (originalBulbMode != BulbMode::BULB_MODE_COLOR)) {
+      switchMode(*ourState, originalBulbMode);
+    }
+  }
+}
+
+void S2PacketFormatter::updateColorWhite() {
+  // there is no direct white command, so let's look up our prior temperature and set that, which
+  // causes the bulb to go white
+  const GroupState* ourState = this->stateStore->get(this->deviceId, this->groupId, REMOTE_TYPE_S2);
+  uint8_t value =
+    ourState == NULL
+      ? 0
+      : ourState->getKelvin();
+
+  // issue command to set kelvin to prior value, which will drive to white
+  command(S2_KELVIN, value);
+}
+
+void S2PacketFormatter::enableNightMode() {
+  uint8_t arg = groupCommandArg(OFF, groupId);
+  command(S2_ON_OFF | 0x80, arg);
+}
+
+BulbId S2PacketFormatter::parsePacket(const uint8_t *packet, JsonObject result) {
+  uint8_t packetCopy[V2_PACKET_LEN];
+  memcpy(packetCopy, packet, V2_PACKET_LEN);
+  V2RFEncoding::decodeV2Packet(packetCopy);
+
+  BulbId bulbId(
+    (packetCopy[2] << 8) | packetCopy[3],
+    packetCopy[7],
+    REMOTE_TYPE_S2
+  );
+
+  uint8_t command = (packetCopy[V2_COMMAND_INDEX] & 0x7F);
+  uint8_t arg = packetCopy[V2_ARGUMENT_INDEX];
+
+  if (command == S2_ON_OFF) {
+    if ((packetCopy[V2_COMMAND_INDEX] & 0x80) == 0x80) {
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::NIGHT_MODE;
+    } else if (arg == 0x01) {
+      result[GroupStateFieldNames::STATE] = "ON";
+    } else if (arg == 0x0A) {
+      result[GroupStateFieldNames::STATE] = "OFF";
+    } else if (arg == 0x14) {
+      // todo: this detects pressing of "palette key" on my remote
+      // don't really know how to map it...
+      result["button_id"] = "palette";
+    }
+  } else if (command == S2_COLOR) {
+    uint16_t hue = Units::rescale<uint16_t, uint16_t>(arg, 360, 255.0);
+    result[GroupStateFieldNames::HUE] = hue;
+  } else if (command == S2_KELVIN) {
+    uint8_t temperature = arg;
+    result[GroupStateFieldNames::COLOR_TEMP] = Units::whiteValToMireds(temperature, 100);
+  } else if (command == S2_BRIGHTNESS) {
+    result[GroupStateFieldNames::BRIGHTNESS] = Units::rescale<uint8_t, uint8_t>(arg, 255, 100);
+  } else if (command == S2_SATURATION) {
+    result[GroupStateFieldNames::SATURATION] = arg;
+  } else if (command == S2_MODE) {
+    result[GroupStateFieldNames::MODE] = arg;
+  } else {
+    result["button_id"] = command;
+    result["argument"] = arg;
+  }
+
+  return bulbId;
+}

--- a/components/mi/S2PacketFormatter.h
+++ b/components/mi/S2PacketFormatter.h
@@ -1,0 +1,42 @@
+#pragma once
+#include "V2PacketFormatter.h"
+#include "MiLightRemoteType.h"
+
+#define S2_NUM_MODES 9
+
+#define S2_COLOR_OFFSET 0x5F
+
+enum S2Command {
+  S2_ON_OFF = 0x01,
+  S2_COLOR = 0x02,
+  S2_KELVIN = 0x03,
+  S2_SATURATION = 0x04,
+  S2_BRIGHTNESS = 0x05,
+  S2_MODE = 0x06
+};
+
+class S2PacketFormatter : public V2PacketFormatter {
+public:
+  S2PacketFormatter()
+    : V2PacketFormatter(REMOTE_TYPE_S2, 0x21, 4),
+      lastMode(0)
+  { }
+
+  virtual void updateBrightness(uint8_t value);
+  virtual void updateHue(uint16_t value);
+  virtual void updateColorRaw(uint8_t value);
+  virtual void updateColorWhite();
+  virtual void updateTemperature(uint8_t value);
+  virtual void updateSaturation(uint8_t value);
+  virtual void enableNightMode();
+
+  virtual void updateMode(uint8_t mode);
+  virtual void nextMode();
+  virtual void previousMode();
+
+  virtual BulbId parsePacket(const uint8_t* packet, JsonObject result);
+
+protected:
+
+  uint8_t lastMode;
+};

--- a/components/mi/button/__init__.py
+++ b/components/mi/button/__init__.py
@@ -15,6 +15,7 @@ REMOTE_TYPES = {
     "fut089" : "fut089",
     "fut091" : "fut091",
     "fut020" : "fut020",
+    "s2" : "s2",
 }
 
 COMMANDS = {

--- a/components/mi/light/__init__.py
+++ b/components/mi/light/__init__.py
@@ -20,6 +20,7 @@ REMOTE_TYPES = {
     "fut089" : "fut089",
     "fut091" : "fut091",
     "fut020" : "fut020",
+    "s2" : "s2",
 }
 
 

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -63,6 +63,11 @@ namespace esphome {
         case REMOTE_TYPE_FUT020:
           traits.set_supported_color_modes({light::ColorMode::RGB});
           break;
+        case REMOTE_TYPE_S2:
+          traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE});
+          traits.set_max_mireds(warm_white_temperature_);
+          traits.set_min_mireds(cold_white_temperature_);
+          break;
         default:
           traits.set_supported_color_modes({light::ColorMode::ON_OFF});
           break;

--- a/components/mi/mi.h
+++ b/components/mi/mi.h
@@ -41,6 +41,7 @@
 #include "FUT02xPacketFormatter.h"
 #include "FUT089PacketFormatter.h"
 #include "FUT091PacketFormatter.h"
+#include "S2PacketFormatter.h"
 #include "PacketFormatter.h"
 #include "MiLightRemoteConfig.h"
 #include "FUT020PacketFormatter.h"

--- a/components/mi/switch/__init__.py
+++ b/components/mi/switch/__init__.py
@@ -15,6 +15,7 @@ REMOTE_TYPES = {
     "fut089" : "fut089",
     "fut091" : "fut091",
     "fut020" : "fut020",
+    "s2" : "s2",
 }
 
 COMMANDS = {

--- a/example_milight.yaml
+++ b/example_milight.yaml
@@ -85,7 +85,7 @@ light:
     name: ${friendly_name} #required
     device_id: 0xAB01 #required, hexadacimal value of MiLight id
     group_id: 1 #required, 1-4 or 1-8, depending on remote type
-    remote_type: rgb_cct #required, possible values: rgb_cct, rgb, cct, rgbw, fut089, fut091, fut020
+    remote_type: rgb_cct #required, possible values: rgb_cct, rgb, cct, rgbw, fut089, fut091, fut020, s2
     default_transition_length: 0s #optional, but 0s gives a better behaviour instead the default 200ms
   # Set these to calibrate the color temperature of your light, measured with an external color temp. sensor or app
   # optional, [153, 370] mireds is the range miboxer uses internally ([6535, 2702] K)


### PR DESCRIPTION
By combining two different packet formatters, I managed to have my [Mi Light S2 remote](https://miboxer.com/product/2-4g-rainbow-remote-rgbcct/) working somewhat - at least the part that decodes packets and sends them to HA.
As I don't have any compatible MI light, I am not sure if the converted values make sense. I am hoping someone (possibly with the same remote and the actual light) can help me with that.
Or I can post here the raw values sent by remote and we might compare them against other remotes and see if any of them produces exactly the same - then we can re-use this part of code from these remotes.
Btw. the manual for this remote can be found [here](https://miboxer.com/light/m_n/pdf/SL2/S2-B-W-G_V2.0_EN.pdf).

BRIGTHNESS  CMD=5, ARG=0-100
SATURATION  CMD=4, ARG=0-100
KELVIN      CMD=3, ARG=0-100
COLOR       CMD=2, ARG=255-0
DYNAMIC_MODE_SWITCHING CMD=6, ARG=0-8

I got S2 **almost** working in HA (ie. use it to control a Wifi-enabled RGB-CCT light), but still working for changing colors - as the remote provides them in hsb and not rgb.

Of course this is not meant to be merged yet, I only opened this PR to ask for help with finishing it :)