### PR TITLE
ESPHome MiLight BugFixes + Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml
+__pycache__

--- a/components/mi/MiLightClient.cpp
+++ b/components/mi/MiLightClient.cpp
@@ -434,12 +434,27 @@ void MiLightClient::handleCommand(JsonVariant command) {
 }
 
 void MiLightClient::handleEffect(const String& effect) {
-  if (effect == MiLightCommandNames::NIGHT_MODE) {
+  #ifdef DEBUG_CLIENT_COMMANDS
+  Serial.printf_P(PSTR("Request to handle effect '%s' in MiLight component."), effect);
+  #endif
+  if (effect.startsWith("Mi ") != true) {
+    // This is not a MiLight built-in effect. We don't need to handle it here.
+    #ifdef DEBUG_CLIENT_COMMANDS
+    Serial.printf_P(PSTR("This is not a MiLight built-in effect."));
+    #endif
+    return;
+  }
+  int effectId = effect.substring(3, 5).toInt();
+  if (effectId < 0 || effectId > 9) {
+    #ifdef DEBUG_CLIENT_COMMANDS
+    Serial.printf_P(PSTR("Invalid effect ID at position 3-4: %d. MiLights only support effect ids 1-9."), effectId);
+    #endif
+    return;
+  }
+  if (effectId == 0) {
     this->enableNightMode();
-  } else if (effect == "white" || effect == "white_mode") {
-    this->updateColorWhite();
-  } else { // assume we're trying to set mode
-    this->updateMode(effect.toInt());
+  } else {
+    this->updateMode((uint8_t) (effectId & 0xFF));
   }
 }
 

--- a/components/mi/MiLightClient.cpp
+++ b/components/mi/MiLightClient.cpp
@@ -412,9 +412,9 @@ void MiLightClient::handleCommand(JsonVariant command) {
     this->increaseBrightness();
   } else if (cmdName == MiLightCommandNames::LEVEL_DOWN) {
     this->decreaseBrightness();
-  } else if (cmdName == "brightness_up") {
+  } else if (cmdName == MiLightCommandNames::BRIGHTNESS_UP) {
     this->increaseBrightness();
-  } else if (cmdName == "brightness_down") {
+  } else if (cmdName == MiLightCommandNames::BRIGHTNESS_DOWN) {
     this->decreaseBrightness();
   } else if (cmdName == MiLightCommandNames::TEMPERATURE_UP) {
     this->increaseTemperature();

--- a/components/mi/MiLightCommands.h
+++ b/components/mi/MiLightCommands.h
@@ -18,3 +18,16 @@ namespace MiLightCommandNames {
   static const char TOGGLE[] = "toggle";
   static const char TRANSITION[] = "transition";
 };
+
+static const std::string DISCO_MODE_NAMES[] = {
+    "Mi 00: Night Mode",
+    "Mi 01: Rainbow",
+    "Mi 02: Low-Sat Rainbow",
+    "Mi 03: No-Red Rainbow",
+    "Mi 04: Fast Rainbow",
+    "Mi 05: Red-White-Bue",
+    "Mi 06: Pink-Blue-White",
+    "Mi 07: Green-Blue-Red-White",
+    "Mi 08: Slow Random Fade",
+    "Mi 09: Slow Blue-Green Fade"
+};

--- a/components/mi/MiLightCommands.h
+++ b/components/mi/MiLightCommands.h
@@ -9,6 +9,8 @@ namespace MiLightCommandNames {
   static const char LEVEL_DOWN[] = "level_down";
   static const char TEMPERATURE_UP[] = "temperature_up";
   static const char TEMPERATURE_DOWN[] = "temperature_down";
+  static const char BRIGHTNESS_UP[] = "brightness_up";
+  static const char BRIGHTNESS_DOWN[] = "brightness_down";
   static const char NEXT_MODE[] = "next_mode";
   static const char PREVIOUS_MODE[] = "previous_mode";
   static const char MODE_SPEED_DOWN[] = "mode_speed_down";

--- a/components/mi/MiLightCommands.h
+++ b/components/mi/MiLightCommands.h
@@ -25,7 +25,7 @@ static const std::string DISCO_MODE_NAMES[] = {
     "Mi 02: Low-Sat Rainbow",
     "Mi 03: No-Red Rainbow",
     "Mi 04: Fast Rainbow",
-    "Mi 05: Red-White-Bue",
+    "Mi 05: Red-White-Blue",
     "Mi 06: Pink-Blue-White",
     "Mi 07: Green-Blue-Red-White",
     "Mi 08: Slow Random Fade",

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -1,6 +1,7 @@
 #include "esphome.h"
 #include "esphome/core/log.h"
 #include "mi_light.h"
+#include "../MiLightCommands.h"
 #include "esphome/core/helpers.h"
 
 
@@ -80,9 +81,9 @@ namespace esphome {
 
       parent_->add_child(state_->get_object_id_hash(), bulbId);
 
-      state_->add_effects({new light::LambdaLightEffect("night_mode", [=](bool initial_run) -> void {
+      state_->add_effects({new light::LambdaLightEffect(DISCO_MODE_NAMES[0], [=](bool initial_run) -> void {
         auto call = state_->make_call();
-        call.set_effect("night_mode");
+        call.set_effect(DISCO_MODE_NAMES[0]);
         call.perform();
         }, 360000)
       });
@@ -94,10 +95,11 @@ namespace esphome {
           MiLight::bulbId.deviceType == REMOTE_TYPE_FUT020
           ) {
 
-        for (int i = 0; i < 9; i++) {
-          state_->add_effects({new light::LambdaLightEffect(esphome::to_string(i), [=](bool initial_run) -> void {
+        // Add the 9 built-in effects with descriptive names...
+        for (int i = 1; i < 10; i++) {
+          state_->add_effects({new light::LambdaLightEffect(DISCO_MODE_NAMES[i], [=](bool initial_run) -> void {
             auto call = state_->make_call();
-            call.set_effect(i);
+            call.set_effect(DISCO_MODE_NAMES[i]);
             call.perform();
             }, 360000)
           });

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -85,7 +85,7 @@ namespace esphome {
         auto call = state_->make_call();
         call.set_effect(DISCO_MODE_NAMES[0]);
         call.perform();
-        }, 0xfffffff)
+        }, 0xffffffff)
       });
       
       if (MiLight::bulbId.deviceType == REMOTE_TYPE_RGB_CCT || 
@@ -101,7 +101,7 @@ namespace esphome {
             auto call = state_->make_call();
             call.set_effect(DISCO_MODE_NAMES[i]);
             call.perform();
-            }, 0xfffffff)
+            }, 0xffffffff)
           });
         }
       }

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -85,7 +85,7 @@ namespace esphome {
         auto call = state_->make_call();
         call.set_effect(DISCO_MODE_NAMES[0]);
         call.perform();
-        }, 360000)
+        }, 0xfffffff)
       });
       
       if (MiLight::bulbId.deviceType == REMOTE_TYPE_RGB_CCT || 
@@ -94,14 +94,14 @@ namespace esphome {
           MiLight::bulbId.deviceType == REMOTE_TYPE_FUT089 ||
           MiLight::bulbId.deviceType == REMOTE_TYPE_FUT020
           ) {
-
+        
         // Add the 9 built-in effects with descriptive names...
         for (int i = 1; i < 10; i++) {
           state_->add_effects({new light::LambdaLightEffect(DISCO_MODE_NAMES[i], [=](bool initial_run) -> void {
             auto call = state_->make_call();
             call.set_effect(DISCO_MODE_NAMES[i]);
             call.perform();
-            }, 360000)
+            }, 0xfffffff)
           });
         }
       }

--- a/components/mi/mi.cpp
+++ b/components/mi/mi.cpp
@@ -327,6 +327,10 @@ namespace esphome {
         effectChr[effect.size()] = '\0';
          
         root["effect"] = effectChr;
+        if (traits.supports_color_capability(light::ColorCapability::BRIGHTNESS)) {
+          root["brightness"] = uint8_t(values.get_brightness() * 255);
+        }
+
       } else {
        
         switch (values.get_color_mode()) {


### PR DESCRIPTION
* Feature: able to set brightness for built-in effects
* Feature: Built-in effects have descriptive English names
* Bugfix: built-in effects are retriggered every 0xFFFFFFFF milliseconds (49 days) instead of every 6 minutes
* Bugfix: Now compatible with ESPHome custom lambda effects