### PR TITLE
Give more time to each config to listen to the remotes

### DIFF
--- a/components/mi/MiLightRadioConfig.cpp
+++ b/components/mi/MiLightRadioConfig.cpp
@@ -3,7 +3,8 @@
 MiLightRadioConfig MiLightRadioConfig::ALL_CONFIGS[] = {
   MiLightRadioConfig(0x147A, 0x258B, 7, 9, 40, 71, 0xAA, 0x05), // rgbw
   MiLightRadioConfig(0x050A, 0x55AA, 7, 4, 39, 74, 0xAA, 0x05), // cct
-  MiLightRadioConfig(0x7236, 0x1809, 9, 8, 39, 70, 0xAA, 0x05), // rgb+cct, fut089, s2
+  MiLightRadioConfig(0x7236, 0x1809, 9, 8, 39, 70, 0xAA, 0x05), // rgb+cct, fut089
   MiLightRadioConfig(0x9AAB, 0xBCCD, 6, 3, 38, 73, 0x55, 0x0A), // rgb
-  MiLightRadioConfig(0x50A0, 0xAA55, 6, 6, 41, 76, 0xAA, 0x0A)  // FUT020
+  MiLightRadioConfig(0x50A0, 0xAA55, 6, 6, 41, 76, 0xAA, 0x0A), // FUT020
+  MiLightRadioConfig(0x7236, 0x1809, 9, 8, 39, 70, 0xAA, 0x05)  // s2
 };

--- a/components/mi/MiLightRadioConfig.h
+++ b/components/mi/MiLightRadioConfig.h
@@ -76,7 +76,7 @@ public:
 
   const size_t packetLength;
 
-  static const size_t NUM_CONFIGS = 5;
+  static const size_t NUM_CONFIGS = 6;
   static MiLightRadioConfig ALL_CONFIGS[NUM_CONFIGS];
 };
 

--- a/components/mi/MiLightRemoteConfig.cpp
+++ b/components/mi/MiLightRemoteConfig.cpp
@@ -110,7 +110,7 @@ const MiLightRemoteConfig FUT020Config(
 
 const MiLightRemoteConfig S2Config( //rgb+cct
   new S2PacketFormatter(),
-  MiLightRadioConfig::ALL_CONFIGS[2],
+  MiLightRadioConfig::ALL_CONFIGS[5],
   REMOTE_TYPE_S2,
   "s2",
   4

--- a/components/mi/mi.cpp
+++ b/components/mi/mi.cpp
@@ -6,6 +6,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/util.h"
 
+#define LOOPS_PER_CONFIG 5
+
 namespace esphome {
   namespace mi {
     
@@ -221,7 +223,9 @@ namespace esphome {
         return;
       }
 
-       const MiLightRemoteConfig* remoteConfig = MiLightRemoteConfig::fromType(Mi::miOutputs[i].bulbId.deviceType);
+      auto configIndex = i/LOOPS_PER_CONFIG;
+
+       const MiLightRemoteConfig* remoteConfig = MiLightRemoteConfig::fromType(Mi::miOutputs[configIndex].bulbId.deviceType);
 
       if (remoteConfig == NULL) {
         // This can happen under normal circumstances, so not an error condition
@@ -229,7 +233,7 @@ namespace esphome {
         return;
       }
 
-      milightClient->prepare(Mi::miOutputs[i].bulbId.deviceType, 0, 0);
+      milightClient->prepare(Mi::miOutputs[configIndex].bulbId.deviceType, 0, 0);
       std::shared_ptr<MiLightRadio> radio = radios->switchRadio(remoteConfig);
       
       if (radios->available()) {
@@ -241,7 +245,7 @@ namespace esphome {
       }
 
       i++;
-      if (i > miOutputs.size()-1) {i=0;}
+      if (i == (miOutputs.size() * LOOPS_PER_CONFIG)) {i=0;}
     }
 
     /**


### PR DESCRIPTION
This gives more time (ie. more loops) for each radio configuration.
Previously the configurations were switched in each loop iteration which was so fast that almost no packet could go through or packets were lost when resetting fifos during reconfig.

This seems to fix  #34

The value LOOPS_PER_CONFIG=5 was chosen somewhat arbitrary. It works fine with my setup (nodemcuv2 + NRF24) and my two configs (see #34 for details), but I don't know if this will be ok for other users. With maximum configurations enabled this might turn out to be too long in total. So maybe this could be a parameter that settable via yaml?