### PR TITLE
    itho: Let ESPHOME handle the status LED

### DIFF
--- a/components/itho/itho.cpp
+++ b/components/itho/itho.cpp
@@ -311,8 +311,6 @@ namespace esphome
 
       ESP_LOGD(TAG, "Setup Itho Core start");
 
-      pinMode(WIFILED, OUTPUT);
-      digitalWrite(WIFILED, HIGH);
       pinMode(STATUSPIN, INPUT_PULLUP);
       pinMode(ITHOSTATUS, OUTPUT);
       digitalWrite(ITHOSTATUS, LOW);

--- a/components/itho/itho.h
+++ b/components/itho/itho.h
@@ -11,7 +11,6 @@ namespace esphome
   namespace itho
   {
 
-#define WIFILED 17
 #define STATUSPIN 16
 #define ITHOSTATUS 13
 

--- a/example_itho.yaml
+++ b/example_itho.yaml
@@ -26,6 +26,7 @@ api:
  reboot_timeout: 480min
 
 ota:
+  - platform: esphome
 
 itho:
   syssht30: disable       ##Optional, default enabled: enable or disable Itho build in sensor and automation, set to disable when using own automation logic

--- a/example_itho.yaml
+++ b/example_itho.yaml
@@ -28,6 +28,15 @@ api:
 ota:
   - platform: esphome
 
+light:
+  - platform: status_led
+    name: "Status LED"
+    id: board_status_led
+    pin:
+      number: 17
+      inverted: true
+    entity_category: diagnostic
+
 itho:
   syssht30: disable       ##Optional, default enabled: enable or disable Itho build in sensor and automation, set to disable when using own automation logic
   syssht30_address: 0x44  ##Optional, default 0x44, I2C SHT30 sensor address


### PR DESCRIPTION
itho: Let ESPHOME handle the status LED
    
The LED is currently only turned on in the component, and never changed
afterwards. Instead, let ESPHome manage the LED, which includes wifi
stuff.
    
