### PR TITLE
Add support for FUT022

### DIFF
--- a/components/mi/FUT022PacketFormatter.cpp
+++ b/components/mi/FUT022PacketFormatter.cpp
@@ -1,0 +1,119 @@
+#include "FUT022PacketFormatter.h"
+#include "Units.h"
+#include "GroupStateField.h"
+#include "MiLightCommands.h"
+
+// ============================================================
+// SENDING — generate packets to control the CCT receiver
+// ============================================================
+
+void FUT022PacketFormatter::updateStatus(MiLightStatus status, uint8_t groupId) {
+  if (status == ON) {
+    command(static_cast<uint8_t>(FUT022Command::ON), 0);
+  } else {
+    command(static_cast<uint8_t>(FUT022Command::OFF), 0);
+  }
+}
+
+void FUT022PacketFormatter::increaseBrightness() {
+  command(static_cast<uint8_t>(FUT022Command::BRIGHTNESS_UP), 0);
+}
+
+void FUT022PacketFormatter::decreaseBrightness() {
+  command(static_cast<uint8_t>(FUT022Command::BRIGHTNESS_DOWN), 0);
+}
+
+void FUT022PacketFormatter::updateBrightness(uint8_t value) {
+  // Use the touch ring to set absolute brightness.
+  // Map 0-255 → ring brightness range (0x80-0xFF).
+  uint8_t ringValue = Units::rescale<uint8_t, uint16_t>(value, RING_BRIGHTNESS_MAX - RING_BRIGHTNESS_MIN, 255);
+  ringValue += RING_BRIGHTNESS_MIN;
+  command(static_cast<uint8_t>(FUT022Command::RING), ringValue);
+}
+
+void FUT022PacketFormatter::increaseTemperature() {
+  // No dedicated temp+ button on FUT022 — simulate via ring
+  // This is a workaround: send a slightly warmer ring position
+  command(static_cast<uint8_t>(FUT022Command::RING), 0x60);
+}
+
+void FUT022PacketFormatter::decreaseTemperature() {
+  // No dedicated temp- button — simulate via ring
+  command(static_cast<uint8_t>(FUT022Command::RING), 0x20);
+}
+
+void FUT022PacketFormatter::updateTemperature(uint8_t value) {
+  // Map 0-255 → ring temperature range (0x00-0x7F).
+  // 0 = coldest, 255 = warmest → ring 0x00 = cold end, 0x7F = warm end
+  uint8_t ringValue = Units::rescale<uint8_t, uint16_t>(value, RING_TEMP_MAX, 255);
+  command(static_cast<uint8_t>(FUT022Command::RING), ringValue);
+}
+
+void FUT022PacketFormatter::updateColorRaw(uint8_t value) {
+  // FUT022 is CCT-only — no color. Treat as ring position for compatibility.
+  command(static_cast<uint8_t>(FUT022Command::RING), value);
+}
+
+// ============================================================
+// RECEIVING — parse packets from FUT022 remote into JSON state
+// ============================================================
+
+BulbId FUT022PacketFormatter::parsePacket(const uint8_t* packet, JsonObject result) {
+  uint8_t cmdByte = packet[FUT02xPacketFormatter::FUT02X_COMMAND_INDEX];
+  FUT022Command cmd = static_cast<FUT022Command>(cmdByte & 0x0F);
+  uint8_t arg = packet[FUT02xPacketFormatter::FUT02X_ARGUMENT_INDEX];
+
+  BulbId bulbId(
+    (packet[1] << 8) | packet[2],
+    0,
+    REMOTE_TYPE_FUT022
+  );
+
+  switch (cmd) {
+    case FUT022Command::ON:
+      result[GroupStateFieldNames::STATE] = "ON";
+      break;
+
+    case FUT022Command::OFF:
+      result[GroupStateFieldNames::STATE] = "OFF";
+      break;
+
+    case FUT022Command::BRIGHTNESS_UP:
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::BRIGHTNESS_UP;
+      break;
+
+    case FUT022Command::BRIGHTNESS_DOWN:
+      result[GroupStateFieldNames::COMMAND] = MiLightCommandNames::BRIGHTNESS_DOWN;
+      break;
+
+    case FUT022Command::MEDIUM:
+      // 50% brightness — emit absolute value
+      result[GroupStateFieldNames::STATE] = "ON";
+      result[GroupStateFieldNames::BRIGHTNESS] = 128;
+      break;
+
+    case FUT022Command::RING:
+      if (arg >= RING_BRIGHTNESS_MIN) {
+        // Left half of ring → absolute brightness
+        // Map 0x80-0xFF → 1-255 (never fully off from ring)
+        uint8_t brightness = Units::rescale<uint8_t, uint16_t>(
+          arg - RING_BRIGHTNESS_MIN,
+          255,
+          RING_BRIGHTNESS_MAX - RING_BRIGHTNESS_MIN
+        );
+        if (brightness < 1) brightness = 1;
+        result[GroupStateFieldNames::BRIGHTNESS] = brightness;
+      } else {
+        // Right half of ring → absolute color temperature
+        // Map 0x00-0x7F → 153-370 mireds (warm to cold, typical CCT range)
+        // 153 mireds = 6500K (cold), 370 mireds = 2700K (warm)
+        // Ring value 0x00 = cold end, 0x7F = warm end
+        uint16_t mireds = Units::rescale<uint16_t, uint16_t>(arg, 370 - 153, RING_TEMP_MAX);
+        mireds += 153;
+        result[GroupStateFieldNames::COLOR_TEMP] = mireds;
+      }
+      break;
+  }
+
+  return bulbId;
+}

--- a/components/mi/FUT022PacketFormatter.cpp
+++ b/components/mi/FUT022PacketFormatter.cpp
@@ -24,9 +24,9 @@ void FUT022PacketFormatter::decreaseBrightness() {
 }
 
 void FUT022PacketFormatter::updateBrightness(uint8_t value) {
-  // Use the touch ring to set absolute brightness.
-  // Map 0-255 → ring brightness range (0x80-0xFF).
-  uint8_t ringValue = Units::rescale<uint8_t, uint16_t>(value, RING_BRIGHTNESS_MAX - RING_BRIGHTNESS_MIN, 255);
+  // MiLightClient passes brightness as 0-100.
+  // Map to ring brightness range (0x80-0xFF).
+  uint8_t ringValue = Units::rescale<uint8_t, uint16_t>(value, RING_BRIGHTNESS_MAX - RING_BRIGHTNESS_MIN, 100);
   ringValue += RING_BRIGHTNESS_MIN;
   command(static_cast<uint8_t>(FUT022Command::RING), ringValue);
 }
@@ -43,9 +43,9 @@ void FUT022PacketFormatter::decreaseTemperature() {
 }
 
 void FUT022PacketFormatter::updateTemperature(uint8_t value) {
-  // Map 0-255 → ring temperature range (0x00-0x7F).
-  // 0 = coldest, 255 = warmest → ring 0x00 = cold end, 0x7F = warm end
-  uint8_t ringValue = Units::rescale<uint8_t, uint16_t>(value, RING_TEMP_MAX, 255);
+  // MiLightClient passes temperature as 0-100 (0=cold, 100=warm).
+  // Map to ring temperature range (0x00-0x7F).
+  uint8_t ringValue = Units::rescale<uint8_t, uint16_t>(value, RING_TEMP_MAX, 100);
   command(static_cast<uint8_t>(FUT022Command::RING), ringValue);
 }
 

--- a/components/mi/FUT022PacketFormatter.cpp
+++ b/components/mi/FUT022PacketFormatter.cpp
@@ -2,6 +2,7 @@
 #include "Units.h"
 #include "GroupStateField.h"
 #include "MiLightCommands.h"
+#include "esphome/core/log.h"
 
 // ============================================================
 // SENDING — generate packets to control the CCT receiver
@@ -93,6 +94,7 @@ BulbId FUT022PacketFormatter::parsePacket(const uint8_t* packet, JsonObject resu
       break;
 
     case FUT022Command::RING:
+      ESP_LOGW("FUT022", "RING raw arg=0x%02X (%d)", arg, arg);
       if (arg >= RING_BRIGHTNESS_MIN) {
         // Left half of ring → absolute brightness
         // Map 0x80-0xFF → 1-255 (never fully off from ring)

--- a/components/mi/FUT022PacketFormatter.cpp
+++ b/components/mi/FUT022PacketFormatter.cpp
@@ -44,8 +44,8 @@ void FUT022PacketFormatter::decreaseTemperature() {
 
 void FUT022PacketFormatter::updateTemperature(uint8_t value) {
   // MiLightClient passes temperature as 0-100 (0=cold, 100=warm).
-  // Map to ring temperature range (0x00-0x7F).
-  uint8_t ringValue = Units::rescale<uint8_t, uint16_t>(value, RING_TEMP_MAX, 100);
+  // Ring temperature range: 0x7F=cold, 0x00=warm (inverted).
+  uint8_t ringValue = RING_TEMP_MAX - Units::rescale<uint8_t, uint16_t>(value, RING_TEMP_MAX, 100);
   command(static_cast<uint8_t>(FUT022Command::RING), ringValue);
 }
 
@@ -105,10 +105,8 @@ BulbId FUT022PacketFormatter::parsePacket(const uint8_t* packet, JsonObject resu
         result[GroupStateFieldNames::BRIGHTNESS] = brightness;
       } else {
         // Right half of ring → absolute color temperature
-        // Map 0x00-0x7F → 153-370 mireds (warm to cold, typical CCT range)
-        // 153 mireds = 6500K (cold), 370 mireds = 2700K (warm)
-        // Ring value 0x00 = cold end, 0x7F = warm end
-        uint16_t mireds = Units::rescale<uint16_t, uint16_t>(arg, 370 - 153, RING_TEMP_MAX);
+        // Ring value 0x7F = cold (153 mireds), 0x00 = warm (370 mireds)
+        uint16_t mireds = Units::rescale<uint16_t, uint16_t>(RING_TEMP_MAX - arg, 370 - 153, RING_TEMP_MAX);
         mireds += 153;
         result[GroupStateFieldNames::COLOR_TEMP] = mireds;
       }

--- a/components/mi/FUT022PacketFormatter.cpp
+++ b/components/mi/FUT022PacketFormatter.cpp
@@ -26,27 +26,26 @@ void FUT022PacketFormatter::decreaseBrightness() {
 
 void FUT022PacketFormatter::updateBrightness(uint8_t value) {
   // MiLightClient passes brightness as 0-100.
-  // Map to ring brightness range (0x80-0xFF).
+  // Map to ring brightness range (RING_BRIGHTNESS_MIN-RING_BRIGHTNESS_MAX).
   uint8_t ringValue = Units::rescale<uint8_t, uint16_t>(value, RING_BRIGHTNESS_MAX - RING_BRIGHTNESS_MIN, 100);
   ringValue += RING_BRIGHTNESS_MIN;
   command(static_cast<uint8_t>(FUT022Command::RING), ringValue);
 }
 
 void FUT022PacketFormatter::increaseTemperature() {
-  // No dedicated temp+ button on FUT022 — simulate via ring
-  // This is a workaround: send a slightly warmer ring position
-  command(static_cast<uint8_t>(FUT022Command::RING), 0x60);
+  // No dedicated temp+ button on FUT022 — simulate via ring (warmer)
+  command(static_cast<uint8_t>(FUT022Command::RING), RING_TEMP_MIN);
 }
 
 void FUT022PacketFormatter::decreaseTemperature() {
-  // No dedicated temp- button — simulate via ring
-  command(static_cast<uint8_t>(FUT022Command::RING), 0x20);
+  // No dedicated temp- button — simulate via ring (cooler)
+  command(static_cast<uint8_t>(FUT022Command::RING), RING_TEMP_MAX);
 }
 
 void FUT022PacketFormatter::updateTemperature(uint8_t value) {
   // MiLightClient passes temperature as 0-100 (0=cold, 100=warm).
-  // Ring temperature range: 0x7F=cold, 0x00=warm (inverted).
-  uint8_t ringValue = RING_TEMP_MAX - Units::rescale<uint8_t, uint16_t>(value, RING_TEMP_MAX, 100);
+  // Ring: RING_TEMP_MAX=cold, RING_TEMP_MIN=warm.
+  uint8_t ringValue = RING_TEMP_MAX - Units::rescale<uint8_t, uint16_t>(value, RING_TEMP_MAX - RING_TEMP_MIN, 100);
   command(static_cast<uint8_t>(FUT022Command::RING), ringValue);
 }
 
@@ -97,9 +96,9 @@ BulbId FUT022PacketFormatter::parsePacket(const uint8_t* packet, JsonObject resu
       ESP_LOGW("FUT022", "RING raw arg=0x%02X (%d)", arg, arg);
       if (arg >= RING_BRIGHTNESS_MIN) {
         // Left half of ring → absolute brightness
-        // Map 0x80-0xFF → 1-255 (never fully off from ring)
+        uint8_t clamped = constrain(arg, RING_BRIGHTNESS_MIN, RING_BRIGHTNESS_MAX);
         uint8_t brightness = Units::rescale<uint8_t, uint16_t>(
-          arg - RING_BRIGHTNESS_MIN,
+          clamped - RING_BRIGHTNESS_MIN,
           255,
           RING_BRIGHTNESS_MAX - RING_BRIGHTNESS_MIN
         );
@@ -107,8 +106,11 @@ BulbId FUT022PacketFormatter::parsePacket(const uint8_t* packet, JsonObject resu
         result[GroupStateFieldNames::BRIGHTNESS] = brightness;
       } else {
         // Right half of ring → absolute color temperature
-        // Ring value 0x7F = cold (153 mireds), 0x00 = warm (370 mireds)
-        uint16_t mireds = Units::rescale<uint16_t, uint16_t>(RING_TEMP_MAX - arg, 370 - 153, RING_TEMP_MAX);
+        // RING_TEMP_MAX = coldest, RING_TEMP_MIN = warmest
+        uint8_t clamped = constrain(arg, RING_TEMP_MIN, RING_TEMP_MAX);
+        uint16_t mireds = Units::rescale<uint16_t, uint16_t>(
+          RING_TEMP_MAX - clamped, 370 - 153, RING_TEMP_MAX - RING_TEMP_MIN
+        );
         mireds += 153;
         result[GroupStateFieldNames::COLOR_TEMP] = mireds;
       }

--- a/components/mi/FUT022PacketFormatter.h
+++ b/components/mi/FUT022PacketFormatter.h
@@ -49,9 +49,9 @@ public:
   // Instead, the configured output's remoteConfig is used as fallback.
   virtual bool canHandle(const uint8_t* packet, const size_t len) override { return false; }
 
-  // Ring arg value ranges
-  static const uint8_t RING_BRIGHTNESS_MIN = 0x80;  // left half of ring
-  static const uint8_t RING_BRIGHTNESS_MAX = 0xFF;
-  static const uint8_t RING_TEMP_MIN       = 0x00;  // right half of ring
-  static const uint8_t RING_TEMP_MAX       = 0x7F;
+  // Ring arg value ranges (calibrated from physical remote captures)
+  static const uint8_t RING_BRIGHTNESS_MIN = 0x90;  // left half of ring — dimmest
+  static const uint8_t RING_BRIGHTNESS_MAX = 0xF5;  // left half of ring — brightest
+  static const uint8_t RING_TEMP_MIN       = 0x15;  // right half of ring — warmest
+  static const uint8_t RING_TEMP_MAX       = 0x75;  // right half of ring — coldest
 };

--- a/components/mi/FUT022PacketFormatter.h
+++ b/components/mi/FUT022PacketFormatter.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "FUT02xPacketFormatter.h"
+
+// FUT022 CCT Remote — command mapping (reverse-engineered from real FUT022 captures)
+// Uses same radio config as FUT020 (syncword 0x50A0/0xAA55, channels 6/41/76, 6-byte packets)
+// but button-to-command assignment differs:
+//
+// Physical button → Command byte (low nibble):
+//   ON              → 0x02
+//   OFF             → 0x05
+//   Brightness+     → 0x03
+//   Brightness-     → 0x01
+//   Medium (50%)    → 0x04
+//   Touch Ring      → 0x00  (arg = position: ≥0x80 = brightness, <0x80 = color temp)
+//
+// Bit 4 of command byte = "held" flag (set on repeat while button is held)
+
+enum class FUT022Command {
+  RING            = 0x00,   // Touch ring — arg encodes brightness or color temp
+  BRIGHTNESS_DOWN = 0x01,
+  ON              = 0x02,
+  BRIGHTNESS_UP   = 0x03,
+  MEDIUM          = 0x04,   // Set brightness to ~50%
+  OFF             = 0x05
+};
+
+class FUT022PacketFormatter : public FUT02xPacketFormatter {
+public:
+  FUT022PacketFormatter()
+    : FUT02xPacketFormatter(REMOTE_TYPE_FUT022)
+  { }
+
+  // --- Sending commands ---
+  virtual void updateStatus(MiLightStatus status, uint8_t groupId) override;
+  virtual void updateBrightness(uint8_t value) override;
+  virtual void increaseBrightness() override;
+  virtual void decreaseBrightness() override;
+  virtual void updateColorRaw(uint8_t value) override;
+  virtual void increaseTemperature() override;
+  virtual void decreaseTemperature() override;
+  virtual void updateTemperature(uint8_t value) override;
+
+  // --- Receiving/parsing ---
+  virtual BulbId parsePacket(const uint8_t* packet, JsonObject result) override;
+
+  // Override canHandle to return false — prevents fromReceivedPacket() from
+  // auto-detecting as FUT022 (would conflict with FUT020 which has same radio config).
+  // Instead, the configured output's remoteConfig is used as fallback.
+  virtual bool canHandle(const uint8_t* packet, const size_t len) override { return false; }
+
+  // Ring arg value ranges
+  static const uint8_t RING_BRIGHTNESS_MIN = 0x80;  // left half of ring
+  static const uint8_t RING_BRIGHTNESS_MAX = 0xFF;
+  static const uint8_t RING_TEMP_MIN       = 0x00;  // right half of ring
+  static const uint8_t RING_TEMP_MAX       = 0x7F;
+};

--- a/components/mi/MiLightRemoteConfig.cpp
+++ b/components/mi/MiLightRemoteConfig.cpp
@@ -12,7 +12,8 @@ const MiLightRemoteConfig* MiLightRemoteConfig::ALL_REMOTES[] = {
   &FUT089Config, // 8-group rgb+cct (b8, fut089)
   &FUT091Config,
   &FUT020Config,
-  &S2Config
+  &S2Config,
+  &FUT022Config
 };
 
 const size_t MiLightRemoteConfig::NUM_REMOTES = size(ALL_REMOTES);
@@ -114,4 +115,12 @@ const MiLightRemoteConfig S2Config( //rgb+cct
   REMOTE_TYPE_S2,
   "s2",
   4
+);
+
+const MiLightRemoteConfig FUT022Config( //cct (FUT022 remote)
+  new FUT022PacketFormatter(),
+  MiLightRadioConfig::ALL_CONFIGS[4],
+  REMOTE_TYPE_FUT022,
+  "fut022",
+  0
 );

--- a/components/mi/MiLightRemoteConfig.h
+++ b/components/mi/MiLightRemoteConfig.h
@@ -8,6 +8,7 @@
 #include "FUT089PacketFormatter.h"
 #include "FUT091PacketFormatter.h"
 #include "FUT020PacketFormatter.h"
+#include "FUT022PacketFormatter.h"
 #include "S2PacketFormatter.h"
 #include "PacketFormatter.h"
 
@@ -50,6 +51,7 @@ extern const MiLightRemoteConfig FUT089Config; //rgb+cct B8 / FUT089
 extern const MiLightRemoteConfig FUT098Config; //rgb
 extern const MiLightRemoteConfig FUT091Config; //v2 cct
 extern const MiLightRemoteConfig FUT020Config;
+extern const MiLightRemoteConfig FUT022Config;
 extern const MiLightRemoteConfig S2Config;
 
 #endif

--- a/components/mi/MiLightRemoteType.cpp
+++ b/components/mi/MiLightRemoteType.cpp
@@ -9,6 +9,7 @@ static const char* REMOTE_NAME_RGB     = "rgb";
 static const char* REMOTE_NAME_FUT091  = "fut091";
 static const char* REMOTE_NAME_FUT020  = "fut020";
 static const char* REMOTE_NAME_S2      = "s2";
+static const char* REMOTE_NAME_FUT022  = "fut022";
 
 const MiLightRemoteType MiLightRemoteTypeHelpers::remoteTypeFromString(const std::string& type) {
   if (esphome::str_equals_case_insensitive(type, REMOTE_NAME_RGBW) || esphome::str_equals_case_insensitive(type, "fut096")) {
@@ -43,6 +44,10 @@ const MiLightRemoteType MiLightRemoteTypeHelpers::remoteTypeFromString(const std
     return REMOTE_TYPE_S2;
   }
 
+  if (esphome::str_equals_case_insensitive(type, REMOTE_NAME_FUT022)) {
+    return REMOTE_TYPE_FUT022;
+  }
+
   //Serial.print(F("remoteTypeFromString: ERROR - tried to fetch remote config for type: "));
   //Serial.println(type);
 
@@ -67,6 +72,8 @@ const std::string MiLightRemoteTypeHelpers::remoteTypeToString(const MiLightRemo
       return REMOTE_NAME_FUT020;
     case REMOTE_TYPE_S2:
       return REMOTE_NAME_S2;
+    case REMOTE_TYPE_FUT022:
+      return REMOTE_NAME_FUT022;
     default:
       //Serial.print(F("remoteTypeToString: ERROR - tried to fetch remote config name for unknown type: "));
       //Serial.println(type);
@@ -103,6 +110,7 @@ const bool MiLightRemoteTypeHelpers::supportsColorTemp(const MiLightRemoteType t
     case REMOTE_TYPE_CCT:
     case REMOTE_TYPE_FUT089:
     case REMOTE_TYPE_FUT091:
+    case REMOTE_TYPE_FUT022:
     case REMOTE_TYPE_RGB_CCT:
     case REMOTE_TYPE_S2:
       return true;

--- a/components/mi/MiLightRemoteType.h
+++ b/components/mi/MiLightRemoteType.h
@@ -12,6 +12,7 @@ enum MiLightRemoteType {
   REMOTE_TYPE_FUT091  = 5,
   REMOTE_TYPE_FUT020  = 6,
   REMOTE_TYPE_S2      = 7,
+  REMOTE_TYPE_FUT022  = 8,
 };
 
 class MiLightRemoteTypeHelpers {

--- a/components/mi/PL1167_nRF24.cpp
+++ b/components/mi/PL1167_nRF24.cpp
@@ -14,14 +14,21 @@
 #include "RadioUtils.h"
 #include "MiLightRadioConfig.h"
 
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#include "esphome/core/log.h"
+#include "hal/usb_serial_jtag_ll.h"
+static const char *const TAG_RADIO = "mi";
+#endif
+
 static uint16_t calc_crc(uint8_t *data, size_t data_length);
 
 PL1167_nRF24::PL1167_nRF24(RF24 &radio)
   : _radio(radio)
 {
-#ifdef USE_ESP32_ALTERNATE_SPI
-#ifdef USE_ARDUINO
-  _spiBus = new SPIClass(HSPI); //defaults to VSPI
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+  // SPI init deferred to open() — must happen AFTER USB-JTAG pad is released on ESP32-C3
+#elif defined(USE_ESP32_ALTERNATE_SPI) && defined(USE_ARDUINO)
+  _spiBus = new SPIClass(HSPI);
 #if defined(ALT_SPI_MISO_PIN) && \
     defined(ALT_SPI_MOSI_PIN) && \
     defined(ALT_SPI_SCLK_PIN) && \
@@ -31,13 +38,32 @@ PL1167_nRF24::PL1167_nRF24(RF24 &radio)
 #else
   _spiBus->begin();
 #endif
-#endif // USE_ARDUINO
-#endif // USE_ESP32_ALTERNATE_SPI
+#endif
 }
 
 int PL1167_nRF24::open() {
 
-#if defined(USE_ESP32_ALTERNATE_SPI) && defined(USE_ARDUINO)
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+  // Explicitly release GPIO18/GPIO19 from USB-Serial-JTAG peripheral
+  usb_serial_jtag_ll_phy_enable_pad(false);
+  ESP_LOGD(TAG_RADIO, "USB-Serial-JTAG pad disabled — GPIO18/19 freed");
+
+#ifdef USE_ESP32_ALTERNATE_SPI
+#ifdef USE_ARDUINO
+#if defined(ALT_SPI_MISO_PIN) && \
+    defined(ALT_SPI_MOSI_PIN) && \
+    defined(ALT_SPI_SCLK_PIN) && \
+    defined(ALT_SPI_SS_PIN)
+  // Init SPI AFTER USB-JTAG release so GPIO mux succeeds
+  SPI.begin(ALT_SPI_SCLK_PIN, ALT_SPI_MISO_PIN, ALT_SPI_MOSI_PIN, ALT_SPI_SS_PIN);
+  pinMode(ALT_SPI_SS_PIN, OUTPUT);
+  digitalWrite(ALT_SPI_SS_PIN, HIGH);
+  _spiBus = &SPI;
+#endif
+#endif
+#endif
+  _radio.begin(_spiBus);
+#elif defined(USE_ESP32_ALTERNATE_SPI) && defined(USE_ARDUINO)
   _radio.begin(_spiBus);
 #else
   _radio.begin();

--- a/components/mi/button/__init__.py
+++ b/components/mi/button/__init__.py
@@ -15,6 +15,7 @@ REMOTE_TYPES = {
     "fut089" : "fut089",
     "fut091" : "fut091",
     "fut020" : "fut020",
+    "fut022" : "fut022",
     "s2" : "s2",
 }
 

--- a/components/mi/light/__init__.py
+++ b/components/mi/light/__init__.py
@@ -26,6 +26,7 @@ REMOTE_TYPES = {
     "fut089": "fut089",
     "fut091": "fut091",
     "fut020": "fut020",
+    "fut022": "fut022",
     "s2": "s2",
 }
 

--- a/components/mi/light/mi_light.cpp
+++ b/components/mi/light/mi_light.cpp
@@ -66,6 +66,11 @@ light::LightTraits MiLight::get_traits() {
     case REMOTE_TYPE_FUT020:
       traits.set_supported_color_modes({light::ColorMode::RGB});
       break;
+    case REMOTE_TYPE_FUT022:
+      traits.set_supported_color_modes({light::ColorMode::COLOR_TEMPERATURE});
+      traits.set_max_mireds(warm_white_temperature_);
+      traits.set_min_mireds(cold_white_temperature_);
+      break;
     case REMOTE_TYPE_S2:
       traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE});
       traits.set_max_mireds(warm_white_temperature_);

--- a/components/mi/mi.cpp
+++ b/components/mi/mi.cpp
@@ -248,8 +248,15 @@ namespace esphome {
           packetLen
         );
 
+        // Prefer the configured output's formatter when the auto-detected config
+        // shares the same radio config (handles FUT022 vs FUT020 disambiguation —
+        // they share identical over-the-air format but have different command semantics).
+        const MiLightRemoteConfig& effectiveConfig =
+            (newRemoteConfig && &newRemoteConfig->radioConfig != &remoteConfig->radioConfig)
+            ? *newRemoteConfig : *remoteConfig;
+
         // update state to reflect this packet
-        onPacketReceivedHandler(readPacket, newRemoteConfig? *newRemoteConfig : *remoteConfig);
+        onPacketReceivedHandler(readPacket, effectiveConfig);
       }
 
       i++;

--- a/components/mi/switch/__init__.py
+++ b/components/mi/switch/__init__.py
@@ -15,6 +15,7 @@ REMOTE_TYPES = {
     "fut089" : "fut089",
     "fut091" : "fut091",
     "fut020" : "fut020",
+    "fut022" : "fut022",
     "s2" : "s2",
 }
 


### PR DESCRIPTION
I've built a super simple board based on an ESP32-C3 (which I had in stock) at https://github.com/usimd/milight-hub targeting a MiLight FUT022 (so far unsupported). This adds support for the new device flavor and also some fixes to support my layout of the ESP32-C3. If you're interested in adding that device, let me know how to tailor this to get it mergeable.