### PR TITLE
[mi] Fix LambdaLightEffect signature for ESPHome 2026.6 (fixes #98)

### DIFF
--- a/components/mi/light/__init__.py
+++ b/components/mi/light/__init__.py
@@ -78,7 +78,7 @@ LambdaLightEffect = cg.esphome_ns.namespace("light").class_("LambdaLightEffect")
 async def mi_light_effect_to_code(config, effect_id):
 
     lambda_code = cg.RawExpression(f"""
-        [](bool initial_run) -> void {{
+        [](esphome::light::LightState &, bool initial_run) -> void {{
           if (initial_run) {{
             auto call = {OUTPUT_NAME}->make_call();
             call.set_effect("{config[CONF_NAME]}");


### PR DESCRIPTION
ESPHome 2026.6.0 changed `LambdaLightEffect`'s callback signature from `void(bool initial_run)` to `void(light::LightState &, bool initial_run)`. The `mi` light effect codegen in `components/mi/light/__init__.py` still emits the old `[](bool initial_run)` lambda, so every `platform: mi` light fails to compile with: invalid user-defined conversion ... to 'void (*)(esphome::light::LightState&, bool)'.

This adds the (unused) `LightState &` first parameter to match the new signature. Fixes #98.